### PR TITLE
[GITHUB-11] Download APT GPG key from keyserver rather than OpenVPN site

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,10 +19,12 @@
     - boto
     - netaddr
 
-- name: Add OpenVPN gpg key
+- name: Add OpenVPN GPG key
   become: yes
   apt_key:
-    url: https://swupdate.openvpn.net/repos/repo-public.gpg
+    id: 8E6DA8B4E158C569
+    keyserver: hkps.pool.sks-keyservers.net
+    #url: https://swupdate.openvpn.net/repos/repo-public.gpg
     state: present
 
 - name: Install OpenVPN repo


### PR DESCRIPTION
Workaround for issue #11.